### PR TITLE
Correção do link do grupo no Telegram

### DIFF
--- a/2016/2016-09-novatec.md
+++ b/2016/2016-09-novatec.md
@@ -21,4 +21,4 @@ Site: [cuducos.me](http://cuducos.me/)
 
 ## Links Importantes do Meetup
 - [Novatec](https://novatec.com.br/)
-- [Telegram](https://telegram.me/joinchat/CquhWAgxneh4k9v6CQH0wg)
+- [Telegram](https://telegram.me/grupysaopaulo)


### PR DESCRIPTION
O link informado é antigo, e era utilizado quando o grupo foi criado.
